### PR TITLE
BUGFIX: Incorrect partition nuber (base error)

### DIFF
--- a/common/image-android.c
+++ b/common/image-android.c
@@ -425,9 +425,9 @@ static void parse_cmdline(void)
 	fs_argv[1] = "mmc";
 
 	if (!strcmp(devnum, "0"))
-		fs_argv[2] = "0:10";
+		fs_argv[2] = "0:a";
 	else if (!strcmp(devnum, "1"))
-		fs_argv[2] = "1:10";
+		fs_argv[2] = "1:a";
 	else {
 		printf("Invalid devnum\n");
 		goto end;
@@ -521,9 +521,9 @@ static void parse_hw_config(struct hw_config *hw_conf)
 	fs_argv[1] = "mmc";
 
 	if (!strcmp(devnum, "0"))
-		fs_argv[2] = "0:10";
+		fs_argv[2] = "0:a";
 	else if (!strcmp(devnum, "1"))
-		fs_argv[2] = "1:10";
+		fs_argv[2] = "1:a";
 	else {
 		printf("Invalid devnum\n");
 		goto end;
@@ -809,9 +809,9 @@ static int merge_dts_overlay(cmd_tbl_t *cmdtp, struct fdt_header *working_fdt, c
 	fs_argv[1] = "mmc";
 
 	if (!strcmp(devnum, "0"))
-		fs_argv[2] = "0:10";
+		fs_argv[2] = "0:a";
 	else if (!strcmp(devnum, "1"))
-		fs_argv[2] = "1:10";
+		fs_argv[2] = "1:a";
 	else {
 		printf("Invalid devnum\n");
 		goto fail;


### PR DESCRIPTION
This commit fixes a bug introduced in cb0ab9502c1e343ca23e08986c68e611b6ee4043

The problematic commit increased partiton numbers by 1 in order to accomodate the new `splash` partition. However, u-boot uses hexadecimal (base 16) numberting rather than decimal (base 10), meaning some of the changes are now pointing to the wrong partition.